### PR TITLE
fix: obfuscate integration script

### DIFF
--- a/obfuscator-gem/lib/objc-obfuscator/integrator.rb
+++ b/obfuscator-gem/lib/objc-obfuscator/integrator.rb
@@ -24,8 +24,8 @@ module Objc_Obfuscator
         rvm rvmrc trust
         rvm rvmrc load
       fi
-      for file in `grep -rl __obfuscate ${SRCROOT}/*.h`; do; objc-obfuscator obfuscate #{encryption_key}; done"
-      for file in `grep -rl __obfuscate ${SRCROOT}/*.m`; do; objc-obfuscator obfuscate #{encryption_key}; done"
+      for file in `grep -rl __obfuscate ${SRCROOT} --include="*.h"`; do objc-obfuscator obfuscate #{encryption_key} $file; done
+      for file in `grep -rl __obfuscate ${SRCROOT} --include="*.h"`; do objc-obfuscator obfuscate #{encryption_key} $file; done
 
       SCRIPT
 


### PR DESCRIPTION
When I tried the pod I've got a bunch of errors. 
Here it is the version which works on my work station: OS X 10.10.3, Xcode 6.3.2

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/futureworkshops/objc-obfuscator/1)

<!-- Reviewable:end -->
