### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In order to make this whole process transparent to the developer, the strings ha
 
 In order to do that we need to add two shell execution phases to our target: one before and one after the compilation takes place.
 
-The gem takes it a step further, and if you're using [Cocoapods](http://cocoapods.org) in your project, you can integrate the library with one single command:
+The gem takes it a step further, and if you're using [CocoaPods](http://cocoapods.org) in your project, you can integrate the library with one single command:
 
 ```bash
 $ objc-obfuscator integrate myEncryptionKey myproject.xcodeproj


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
